### PR TITLE
Add help & reload commands

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,0 +1,51 @@
+/*
+ * From discord.js docs 
+ * https://discordjs.guide/command-handling/
+ */
+
+const { prefix } = require('../../config');
+
+module.exports = {
+	name: 'help',
+	description: 'List all commands or info about a specific command.',
+	aliases: ['commands'],
+	usage: '[command name]',
+	cooldown: 5,
+	execute(message, args) {
+		const data = [];
+		const { commands } = message.client;
+
+		if (!args.length) {
+			data.push('Here are all of my commands:');
+			data.push(commands.map(command => command.name).join(', '));
+			data.push(`\nYou can send \`${prefix}help [command name]\` to get more info on a specific command`);
+
+			return message.author.send(data, { split: true })
+				.then(() => {
+					if (message.channel.type === 'dm') return;
+					message.reply('I\'ve sent you a DM with all my commands');
+				})
+				.catch(error => {
+					console.error(`Could not send help DM to ${message.author.tag}.\n`, error);
+					message.reply('seems like I can\'t DM you :(');
+				});
+		}
+
+		const name = args[0].toLowerCase();
+		const command = commands.get(name) || commands.find(c => c.aliases && c.aliases.includes(name));
+
+		if (!command) {
+			return message.reply('invalid command');
+		}
+
+		data.push(`**Name:** ${command.name}`);
+
+		if (command.aliases) data.push(`**Aliases:** ${command.aliases.join(', ')}`);
+		if (command.description) data.push(`**Description:** ${command.description}`);
+		if (command.usage) data.push(`**Usage:** ${prefix}${command.name} ${command.usage}`);
+
+		data.push(`**Cooldown:** ${command.cooldown || 3} second(s)`);
+
+		message.channel.send(data, { split: true });
+	},
+};

--- a/src/commands/reload.js
+++ b/src/commands/reload.js
@@ -1,0 +1,33 @@
+/*
+ * From discord.js docs 
+ * https://discordjs.guide/command-handling/
+ */
+
+module.exports = {
+	name: 'reload',
+	description: 'Reloads a command. Reloading saves you from having to restart the bot after updating a command.',
+	args: true,
+	guildOnly: true,
+	execute(message, args) {
+		if (!message.member.hasPermission(['ADMINISTRATOR'])) 
+			return message.reply("You need to be an admin to do this")
+
+		const commandName = args[0].toLowerCase();
+		const command = message.client.commands.get(commandName)
+			|| message.client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
+
+		if (!command) 
+			return message.channel.send(`There is no command with name or alias \`${commandName}\`, ${message.author}`);
+
+		delete require.cache[require.resolve(`./${command.name}.js`)];
+
+		try {
+			const newCommand = require(`./${command.name}.js`);
+			message.client.commands.set(newCommand.name, newCommand);
+			message.channel.send(`Command \`${command.name}\` was reloaded`);
+		} catch (error) {
+			console.error(error);
+			message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
+		}
+	},
+};


### PR DESCRIPTION
The bot doesn't have the two arguably most useful commands, added them with references to the docs.

`Help` allows listing all commands and getting more information for specific ones, this is dynamic and doesn't need to be updated.
`Reload` allows refreshing a command without restarting the bot