### PR TITLE
Add kick & ban moderation commands

### DIFF
--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -26,7 +26,7 @@ module.exports = {
 		})
 		.catch((err) => {
 			console.error(err);
-			message.channel.send(`Failed to banned: ${err}`);
+			message.channel.send(`Failed to ban: ${err}`);
 		})
 	},
 };

--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -1,0 +1,33 @@
+const { prefix } = require('../../config');
+const UserHelper = require('./helpers/UserHelper');
+
+module.exports = {
+	name: 'ban',
+	description: 'Ban a member.',
+	guildOnly: true,
+	execute(message) {
+		/* Invoking user needs to have the BAN_MEMBERS perm. Admin perm overrides this by default.
+		 * https://discordjs.guide/popular-topics/permissions.html#checking-for-permissions
+		 */
+		if (!message.member.hasPermission(['BAN_MEMBERS']))
+			return message.reply("You don't have the permission to do this");
+		if (!message.mentions.users.size)
+			return message.reply('You need to tag a user to ban');
+
+		const args = message.content.slice(prefix.length).trim().split(' ');
+		const taggedUser = UserHelper.getMemberFromMention(message, args[1]);
+		const username = taggedUser.user.username;
+		const reason = args.slice(2).join(' ');
+		
+		taggedUser.ban(`${message.author.username}: ${reason}`) // add executing user to reason (to know who did it in the audit log)
+		.then(() => {
+			let output = reason ? `You banned ${username} for ${reason}` : `You banned ${username}`;
+			message.channel.send(output);
+		})
+		.catch((err) => {
+			console.error(err);
+			message.channel.send(`Failed to banned: ${err}`);
+		})
+	},
+};
+

--- a/src/commands/helpers/UserHelper.js
+++ b/src/commands/helpers/UserHelper.js
@@ -1,0 +1,15 @@
+/* 
+ * Function to get GuildMember objects from a mention string
+ * used in Kick and Ban commands
+ 
+ * from discordjs.guide/miscellaneous/parsing-mention-arguments.html#using-regular-expressions
+ * GuildMember: discord.js.org/#/docs/main/11.5.1/class/GuildMember
+ */
+function getMemberFromMention(message, mention) {
+	const matches = mention.match(/^<@!?(\d+)>$/);
+	if (!matches) return;
+	const id = matches[1];
+	return message.guild.members.get(id);
+}
+
+exports.getMemberFromMention = getMemberFromMention;

--- a/src/commands/kick.js
+++ b/src/commands/kick.js
@@ -1,0 +1,32 @@
+const { prefix } = require('../../config');
+const UserHelper = require('./helpers/UserHelper');
+
+module.exports = {
+	name: 'kick',
+	description: 'Kick a member.',
+	guildOnly: true,
+	execute(message) {
+		/* Invoking user needs to have the KICK_MEMBERS perm. Admin perm overrides this by default.
+		 * https://discordjs.guide/popular-topics/permissions.html#checking-for-permissions
+		 */
+		if (!message.member.hasPermission(['KICK_MEMBERS']))
+			return message.reply("You don't have the permission to do this");
+		if (!message.mentions.users.size)
+			return message.reply('You need to tag a user to kick');
+
+		const args = message.content.slice(prefix.length).trim().split(' ');
+		const taggedUser = UserHelper.getMemberFromMention(message, args[1]);
+		const username = taggedUser.user.username;
+		const reason = args.slice(2).join(' ');
+		
+		taggedUser.kick(`${message.author.username}: ${reason}`) // add executing user to reason (to know who did it in the audit log)
+		.then(() => {
+			let output = reason ? `You kicked ${username} for ${reason}` : `You kicked ${username}`;
+			message.channel.send(output);
+		})
+		.catch((err) => {
+			console.error(err);
+			message.channel.send(`Failed to kick: ${err}`);
+		})
+	},
+};


### PR DESCRIPTION
Added kick and ban commands with support for an optional reason for the action.

- `kick` checks if the executing user has the `KICK_MEMBERS` permission
- `ban` checks if the executing user has the `BAN_MEMBERS` permission 
- having the `ADMINISTRATOR` permission overrides these

closes #8 